### PR TITLE
Tweak of the rear and front view controller properties

### DIFF
--- a/RevealControllerProject/ZUUIRevealController/ZUUIRevealController.h
+++ b/RevealControllerProject/ZUUIRevealController/ZUUIRevealController.h
@@ -43,8 +43,8 @@ typedef enum
 @interface ZUUIRevealController : UIViewController <UITableViewDelegate>
 
 // Public Properties:
-@property (retain, nonatomic, readonly) UIViewController *frontViewController;
-@property (retain, nonatomic, readonly) UIViewController *rearViewController;
+@property (retain, nonatomic) IBOutlet UIViewController *frontViewController;
+@property (retain, nonatomic) IBOutlet UIViewController *rearViewController;
 @property (assign, nonatomic) id<ZUUIRevealControllerDelegate> delegate;
 
 // Public Methods:


### PR DESCRIPTION
Hi,
When the ZUUIRevealViewController is created in a XIB, which also contains the rear and front view controllers, it's useful to let the properties be set as IBOutlet.
