### PR TITLE
Don't nil properties after releasing them; add ViewDidUnload.

### DIFF
--- a/RevealControllerProject/ZUUIRevealController/ZUUIRevealController.m
+++ b/RevealControllerProject/ZUUIRevealController/ZUUIRevealController.m
@@ -394,6 +394,13 @@
 	self.frontView.layer.shadowPath = shadowPath.CGPath;
 }
 
+- (void)viewDidUnload
+{
+    // release views as they will be repopulated in viewDidLoad/viewWillAppear
+    self.frontView = nil;
+    self.rearView = nil;
+}
+
 - (void)viewWillAppear:(BOOL)animated
 {
 	[super viewWillAppear:animated];
@@ -435,10 +442,10 @@
 
 - (void)dealloc
 {
-	[_frontViewController release], self.frontViewController = nil;
-	[_rearViewController release], self.rearViewController = nil;
-	[_frontView release], self.frontView = nil;
-	[_rearView release], self.rearView = nil;
+	[_frontViewController release], _frontViewController = nil;
+	[_rearViewController release], _rearViewController = nil;
+	[_frontView release], _frontView = nil;
+	[_rearView release], _rearView = nil;
 
 	[super dealloc];
 }


### PR DESCRIPTION
As frontView and rearView are re-allocated / re-created in viewDidLoad, they can be safely niled out in viewDidUnload, which might save some memory from time to time.

More importantly, don't use property setters to nil out properties after they are released in dealloc - this can result in KVO sending a message to a released object (a zombie condition). Instead, release the properties and then set their backing ivar to nil, which has all of the safety benefits of using the property setter to nil the property with none of the drawbacks.
