### PR TITLE
Quick'n'dirty fix to enable rotation in iOS6.

### DIFF
--- a/ZUUIRevealController/ZUUIRevealController.m
+++ b/ZUUIRevealController/ZUUIRevealController.m
@@ -758,6 +758,10 @@
 	return (toInterfaceOrientation != UIInterfaceOrientationPortraitUpsideDown);
 }
 
+- (NSUInteger)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskAll;
+}
+
 #pragma mark - Memory Management
 
 #if __has_feature(objc_arc)


### PR DESCRIPTION
This enables rotation in iOS6.
