### PR TITLE
bugfix: compiling on sdk < 6.0 should work

### DIFF
--- a/ZUUIRevealController/ZUUIRevealController.m
+++ b/ZUUIRevealController/ZUUIRevealController.m
@@ -758,9 +758,11 @@
 	return (toInterfaceOrientation != UIInterfaceOrientationPortraitUpsideDown);
 }
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED > __IPHONE_5_1
 - (NSUInteger)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskAll;
 }
+#endif
 
 #pragma mark - Memory Management
 


### PR DESCRIPTION
My previous pull request will make compiling impossible when using SDKs lower than 6.0. (UIInterfaceOrientationMaskAll will not be defined). This should fix it.
