### PR TITLE
Better overdraw animation

### DIFF
--- a/ZUUIRevealController/ZUUIRevealController.m
+++ b/ZUUIRevealController/ZUUIRevealController.m
@@ -465,21 +465,15 @@
 - (CGFloat)_calculateOffsetForTranslationInView:(CGFloat)x
 {
 	CGFloat result;
-	
 	if (x <= self.rearViewRevealWidth)
 	{
 		// Translate linearly.
 		result = x;
 	}
-	else if (x <= self.rearViewRevealWidth+(M_PI*self.maxRearViewRevealOverdraw/2.0f))
-	{
-		// and eventually slow translation slowly.
-		result = self.maxRearViewRevealOverdraw*sin((x-self.rearViewRevealWidth)/self.maxRearViewRevealOverdraw)+self.rearViewRevealWidth;
-	}
 	else
-	{
-		// ...until we hit the limit.
-		result = self.rearViewRevealWidth+self.maxRearViewRevealOverdraw;
+    {
+		// and eventually slow translation slowly.
+		result = self.maxRearViewRevealOverdraw*sin((x-self.rearViewRevealWidth)/[[UIScreen mainScreen] bounds].size.width)+self.rearViewRevealWidth;
 	}
 	
 	return result;


### PR DESCRIPTION
Hi,

When you slide the front controller to the right it doesn't slow down when reaching the overdraw. I modded the code so it now slows down till you reach the end of the screen with your finger, just like a UIScrollview. 

If you like this behavior, you could pull. If not, no problem. 

Regards, Tieme
