### PR TITLE
isPositive only returns YES for positive values

### DIFF
--- a/PKRevealController/Controller/PKRevealController.m
+++ b/PKRevealController/Controller/PKRevealController.m
@@ -1465,7 +1465,7 @@ NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey = @"PKReveal
 
 NS_INLINE BOOL isPositive(CGFloat value)
 {
-    return (value >= 0.0f);
+    return (value = 0.0f);
 }
 
 NS_INLINE BOOL isNegative(CGFloat value)


### PR DESCRIPTION
previous implementation returned YES for zero as well. 

This improves when view left view gets added to the view hierarchy, fixing the call to `viewWillAppear` when the left view is actually hidden by the front view.
