### PR TITLE
fix for unwanted scrollview shifting when using content offsets

### DIFF
--- a/PKRevealController/Controller/PKRevealController.m
+++ b/PKRevealController/Controller/PKRevealController.m
@@ -1319,11 +1319,6 @@ NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey = @"PKReveal
 
 - (CGRect)frontViewFrameForCenter
 {
-	// while working with pkrevealcontroller within a tabbarcontroller
-	// where left is vc and right is nc
-	// i noticed unwanted shifting of a collectionview when using the pan gesture
-	// as a note my collectionview content offsets to compensate for translucent navbar 
-
 	CGRect frame = _frontViewController ? _frontViewController.view.bounds : self.view.bounds;
     frame.origin = CGPointMake(0.0f, 0.0f);
     return frame;


### PR DESCRIPTION
while working within a tabbarcontroller where left is vc and right is nc i noticed unwanted shifting of a collectionview when using the pan gesture
note: my collectionview has content offsets to compensate for translucent navbar 
