### PR TITLE
Fix for issue #111 - iOS 5 compatibility

### DIFF
--- a/PKRevealController/Controller/PKRevealController.m
+++ b/PKRevealController/Controller/PKRevealController.m
@@ -1434,8 +1434,8 @@ NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey = @"PKReveal
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
 {
     return [self.frontViewController shouldAutorotateToInterfaceOrientation:toInterfaceOrientation]
-        && [self.leftViewController shouldAutorotateToInterfaceOrientation:toInterfaceOrientation]
-        && [self.rightViewController shouldAutorotateToInterfaceOrientation:toInterfaceOrientation];
+    && (![self hasLeftViewController] || [self.leftViewController shouldAutorotateToInterfaceOrientation:toInterfaceOrientation])
+    && (![self hasRightViewController] ||[self.rightViewController shouldAutorotateToInterfaceOrientation:toInterfaceOrientation]);
 }
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation


### PR DESCRIPTION
At the moment PKRevealController is unusable at iOS 5 if you don't use a **left AND a right** view controller. If you just use one (either left or right) shouldAutorotateToInterfaceOrientation will always return NO and this will let the application crash. (See my issue report https://github.com/pkluz/PKRevealController/issues/111)
