### PR TITLE
Go up in the view controller hierarchy until a reveal controller is found

### DIFF
--- a/PKRevealController/Controller/UIViewController+PKRevealController.m
+++ b/PKRevealController/Controller/UIViewController+PKRevealController.m
@@ -25,7 +25,13 @@ static char revealControllerKey;
 
 - (PKRevealController *)revealController
 {
-    return (PKRevealController *)objc_getAssociatedObject(self, &revealControllerKey);
+    PKRevealController* aRevealController = (PKRevealController *)objc_getAssociatedObject(self, &revealControllerKey);
+    
+    if (aRevealController == nil) {
+        aRevealController = [self.parentViewController revealController];
+    }
+    
+    return aRevealController;
 }
 
 @end


### PR DESCRIPTION
This is similar to how Apple's `navigationController` and `tabBarController` properties work. Goes up the `parentViewController` properties recursively until either a `revealController` is non-nil or the root of the hierarchy has been reached.
