### PR TITLE
Don't remove views from hierarchy when swiping (fixes black screen bug when swiping/clicking menu too fast)

### DIFF
--- a/PKRevealController/Controller/PKRevealController.m
+++ b/PKRevealController/Controller/PKRevealController.m
@@ -1042,8 +1042,6 @@ NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey = @"PKReveal
              [weakSelf.frontViewContainer enableUserInteractionForContainedView];
          }
          weakSelf.state = PKRevealControllerFocusesFrontViewController;
-         [weakSelf removeRightViewControllerFromHierarchy];
-         [weakSelf removeLeftViewControllerFromHierarchy];
          [weakSelf updateResetTapGestureRecognizer];
          safelyExecuteCompletionBlockOnMainThread(completion, finished);
      }];


### PR DESCRIPTION
don't remove views from hierarchy when swiping (fixes black screen bug when swiping/clicking menu too fast)

Fixes https://github.com/pkluz/PKRevealController/issues/102
