### PR TITLE
Gesture recognizer restriction

### DIFF
--- a/PKRevealController/Controller/PKRevealController.m
+++ b/PKRevealController/Controller/PKRevealController.m
@@ -848,6 +848,10 @@ NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey = @"PKReveal
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
+    CGPoint touchPosition = [gestureRecognizer locationInView:self.view];
+    if(!(touchPosition.x < 50.0 || touchPosition.x > self.view.bounds.size.width - 50.0f))
+        return FALSE;
+    
     if (gestureRecognizer == self.revealPanGestureRecognizer)
     {
         CGPoint translation = [self.revealPanGestureRecognizer translationInView:self.frontViewContainer];


### PR DESCRIPTION
Avoid interfering with other gestures interaction on the main view by accepting gesture interation to 50px on the left and right of the view.
