### PR TITLE
 Invalid frames of front view for presentation mode as a current state

### DIFF
--- a/PKRevealController/Controller/PKRevealController.m
+++ b/PKRevealController/Controller/PKRevealController.m
@@ -1298,7 +1298,11 @@ NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey = @"PKReveal
             break;
             
         case PKRevealControllerFocusesLeftViewControllerInPresentationMode:
+			returnRect = [self frontViewFrameForLeftViewPresentationMode];
+			break;
+			
         case PKRevealControllerFocusesRightViewControllerInPresentationMode:
+			returnRect = [self frontViewFrameForRightViewPresentationMode];
             break;
     }
     


### PR DESCRIPTION
Setting a new front view controller while the the PKRevealController is
in presentation mode (either left or right) gives CGRectNull as a new
frame for front container view. Because of this invalid frame of the
front container view, the animation of resigning the presentation mode
displays unintended black view instead of showing the actual front controller view.
And this invalid animation is caused by invalid frame of the front container.
