### PR TITLE
Dynamic enable/disable swiping to left/right viewControllers.

### DIFF
--- a/PKRevealController/Controller/PKRevealController.h
+++ b/PKRevealController/Controller/PKRevealController.h
@@ -129,6 +129,8 @@ typedef void(^PKDefaultErrorHandler)(NSError *error);
 @property (nonatomic, assign, readwrite) BOOL allowsOverdraw;
 @property (nonatomic, assign, readwrite) BOOL disablesFrontViewInteraction;
 @property (nonatomic, assign, readwrite) BOOL recognizesPanningOnFrontView;
+@property (nonatomic, assign, readwrite) BOOL recognizesPanningLeftOnFrontView;
+@property (nonatomic, assign, readwrite) BOOL recognizesPanningRightOnFrontView;
 @property (nonatomic, assign, readwrite) BOOL recognizesResetTapOnFrontView;
 
 #pragma mark - Methods


### PR DESCRIPTION
If a frontViewController is rootViewController of a UINavigationController and it has pushed another viewController - the user may wish to deny that visible viewController swipe access to the leftViewController but allow swipe to the rightViewController, or vice versa. User can set the recognizesPanningLeftOnFrontView to NO or recognizesPanningRightOnFrontView to NO to block swipe gestures from revealing left/right viewControllers. Of course the user will be obligated to set the properties back to YES when that viewController is popped off the navigation stack.
