### PR TITLE
Fix landscape shadow issue on initial launch

### DIFF
--- a/PKRevealController/Controller/PKRevealControllerContainerView.m
+++ b/PKRevealController/Controller/PKRevealControllerContainerView.m
@@ -35,10 +35,6 @@
     if (self != nil)
     {
         self.viewController = controller;
-        if (hasShadow)
-        {
-            [self setupShadow];
-        }
         self.shadow = hasShadow;
     }
     
@@ -64,6 +60,9 @@
 {
     [super layoutSubviews];
     // layout controller view
+    if (self.shadow && !self.layer.shadowPath) {
+        [self setupShadow];
+    }
     self.viewController.view.frame = self.viewController.view.bounds;
 }
 


### PR DESCRIPTION
The view doesn't yet no it's bounds in initForController:shadow: so we must call setupShadow in layoutSubviews.
