### PR TITLE
Fixes container view layout propagation issue

### DIFF
--- a/PKRevealController/Controller/PKRevealControllerContainerView.m
+++ b/PKRevealController/Controller/PKRevealControllerContainerView.m
@@ -64,7 +64,7 @@
 {
     [super layoutSubviews];
     // layout controller view
-    self.viewController.view.frame = self.viewController.view.bounds;
+    self.viewController.view.frame = self.bounds;
 }
 
 - (void)refreshShadowWithAnimationDuration:(NSTimeInterval)duration


### PR DESCRIPTION
I was not able to tell in which exact situation this bug appear, but sometimes, the controller's view of the PKRevealControllerContainerView is not resizing correctly. In my case, in appear while using a UISplitViewController (see screenshots).

![iPad landscape](https://f.cloud.github.com/assets/867666/869451/15e0ef86-f7fd-11e2-9681-3003f895ea37.png)
![iPad portrait](https://f.cloud.github.com/assets/867666/869452/15eb5534-f7fd-11e2-8d63-5136b812dfc5.png)

It seems that the layoutSubviews of PKRevealControllerContainerView should set the controller's view frame to its own bounds instead of the ones of the view. Doing so solves the issue.
