### PR TITLE
Implemented opening of the leftViewController upon rotation and resizing...

### DIFF
--- a/PKRevealController/Controller/PKRevealController.h
+++ b/PKRevealController/Controller/PKRevealController.h
@@ -104,6 +104,40 @@ extern NSString * const PKRevealControllerRecognizesPanningOnFrontViewKey;
  */
 extern NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey;
 
+/*
+ * Determines wether leftViewController is opened during rotation to portrait.
+ *
+ * @default NO
+ * @value NSNumber containing BOOL
+ */
+extern NSString * const PKRevealControllerOpensLeftViewControllerOnPortraitKey;
+
+/*
+ * Determines wether leftViewController is opened during rotation to landscape.
+ *
+ * @default NO
+ * @value NSNumber containing BOOL
+ */
+extern NSString * const PKRevealControllerOpensLeftViewControllerOnLandscapeKey;
+
+/*
+ * Determines wether the frontViewController is resized when leftViewController is shown. Useful
+ * on iPad.
+ *
+ * @default NO
+ * @value NSNumber containing BOOL
+ */
+extern NSString * const PKRevealControllerResizesFrontViewControllerOnPortraitKey;
+
+/*
+ * Determines wether the frontViewController is resized when leftViewController is shown. Useful
+ * on iPad.
+ *
+ * @default NO
+ * @value NSNumber containing BOOL
+ */
+extern NSString * const PKRevealControllerResizesFrontViewControllerOnLandscapeKey;
+
 typedef void(^PKDefaultCompletionHandler)(BOOL finished);
 typedef void(^PKDefaultErrorHandler)(NSError *error);
 
@@ -130,6 +164,10 @@ typedef void(^PKDefaultErrorHandler)(NSError *error);
 @property (nonatomic, assign, readwrite) BOOL disablesFrontViewInteraction;
 @property (nonatomic, assign, readwrite) BOOL recognizesPanningOnFrontView;
 @property (nonatomic, assign, readwrite) BOOL recognizesResetTapOnFrontView;
+@property (nonatomic, assign, readwrite) BOOL opensLeftViewControllerOnPortrait;
+@property (nonatomic, assign, readwrite) BOOL opensLeftViewControllerOnLandscape;
+@property (nonatomic, assign, readwrite) BOOL resizesFrontViewControllerOnPortrait;
+@property (nonatomic, assign, readwrite) BOOL resizesFrontViewControllerOnLandscape;
 
 #pragma mark - Methods
 

--- a/PKRevealController/Controller/PKRevealController.m
+++ b/PKRevealController/Controller/PKRevealController.m
@@ -23,6 +23,10 @@
 #define DEFAULT_DISABLES_FRONT_VIEW_INTERACTION_VALUE YES
 #define DEFAULT_RECOGNIZES_PAN_ON_FRONT_VIEW_VALUE YES
 #define DEFAULT_RECOGNIZES_RESET_TAP_ON_FRONT_VIEW_VALUE YES
+#define DEFAULT_OPENS_LEFT_VIEW_CONTROLLER_ON_LANDSCAPE NO
+#define DEFAULT_OPENS_LEFT_VIEW_CONTROLLER_ON_PORTRAIT NO
+#define DEFAULT_RESIZE_FRONT_VIEW_CONTROLLER_ON_LANDSCAPE NO
+#define DEFAULT_RESIZE_FRONT_VIEW_CONTROLLER_ON_PORTRAIT NO
 
 @interface PKRevealController ()
 
@@ -60,6 +64,11 @@ NSString * const PKRevealControllerQuickSwipeToggleVelocityKey = @"PKRevealContr
 NSString * const PKRevealControllerDisablesFrontViewInteractionKey = @"PKRevealControllerDisablesFrontViewInteractionKey";
 NSString * const PKRevealControllerRecognizesPanningOnFrontViewKey = @"PKRevealControllerRecognizesPanningOnFrontViewKey";
 NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey = @"PKRevealControllerRecognizesResetTapOnFrontViewKey";
+NSString * const PKRevealControllerOpensLeftViewControllerOnPortraitKey = @"PKRevealControllerOpensLeftViewControllerOnPortraitKey";
+NSString * const PKRevealControllerOpensLeftViewControllerOnLandscapeKey = @"PKRevealControllerOpensLeftViewControllerOnLandscapeKey";
+NSString * const PKRevealControllerResizesFrontViewControllerOnPortraitKey = @"PKRevealControllerResizesFrontViewControllerOnPortraitKey";
+NSString * const PKRevealControllerResizesFrontViewControllerOnLandscapeKey = @"PKRevealControllerResizesFrontViewControllerOnLandscapeKey";
+
 
 #pragma mark - Initialization
 
@@ -773,6 +782,91 @@ NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey = @"PKReveal
     }
 }
 
+#pragma mark -
+
+- (void)setOpensLeftViewControllerOnLandscape:(BOOL)opensLeftViewControllerOnLandscape
+{
+    [self.controllerOptions setObject:[NSNumber numberWithBool:opensLeftViewControllerOnLandscape]
+                               forKey:PKRevealControllerOpensLeftViewControllerOnLandscapeKey];
+}
+
+- (BOOL)opensLeftViewControllerOnLandscape {
+    NSNumber *number = [self.controllerOptions objectForKey:PKRevealControllerOpensLeftViewControllerOnLandscapeKey];
+    if (number == nil)
+    {
+        [self setOpensLeftViewControllerOnLandscape:DEFAULT_OPENS_LEFT_VIEW_CONTROLLER_ON_LANDSCAPE];
+        return [self opensLeftViewControllerOnLandscape];
+    }
+    else
+    {
+        return [number boolValue];
+    }
+}
+
+#pragma mark -
+
+- (void)setOpensLeftViewControllerOnPortrait:(BOOL)opensLeftViewControllerOnPortrait
+{
+    [self.controllerOptions setObject:[NSNumber numberWithBool:opensLeftViewControllerOnPortrait]
+                               forKey:PKRevealControllerOpensLeftViewControllerOnPortraitKey];
+}
+
+- (BOOL)opensLeftViewControllerOnPortrait {
+    NSNumber *number = [self.controllerOptions objectForKey:PKRevealControllerOpensLeftViewControllerOnPortraitKey];
+    if (number == nil)
+    {
+        [self setOpensLeftViewControllerOnPortrait:DEFAULT_OPENS_LEFT_VIEW_CONTROLLER_ON_PORTRAIT];
+        return [self opensLeftViewControllerOnPortrait];
+    }
+    else
+    {
+        return [number boolValue];
+    }
+}
+
+#pragma mark -
+
+- (void)setResizesFrontViewControllerOnPortrait:(BOOL)resizesFrontViewControllerOnPortrait
+{
+    [self.controllerOptions setObject:[NSNumber numberWithBool:resizesFrontViewControllerOnPortrait]
+                               forKey:PKRevealControllerResizesFrontViewControllerOnPortraitKey];
+}
+
+- (BOOL)resizesFrontViewControllerOnPortrait
+{
+    NSNumber *number = [self.controllerOptions objectForKey:PKRevealControllerResizesFrontViewControllerOnPortraitKey];
+    if (number == nil)
+    {
+        [self setResizesFrontViewControllerOnPortrait:DEFAULT_RESIZE_FRONT_VIEW_CONTROLLER_ON_PORTRAIT];
+        return [self resizesFrontViewControllerOnPortrait];
+    }
+    else
+    {
+        return [number boolValue];
+    }
+}
+
+#pragma mark -
+
+- (void)setResizesFrontViewControllerOnLandscape:(BOOL)resizesFrontViewControllerOnLandscape
+{
+    [self.controllerOptions setObject:[NSNumber numberWithBool:resizesFrontViewControllerOnLandscape]
+                               forKey:PKRevealControllerResizesFrontViewControllerOnLandscapeKey];
+}
+
+- (BOOL)resizesFrontViewControllerOnLandscape {
+    NSNumber *number = [self.controllerOptions objectForKey:PKRevealControllerResizesFrontViewControllerOnLandscapeKey];
+    if (number == nil)
+    {
+        [self setResizesFrontViewControllerOnLandscape:DEFAULT_RESIZE_FRONT_VIEW_CONTROLLER_ON_LANDSCAPE];
+        return [self resizesFrontViewControllerOnLandscape];
+    }
+    else
+    {
+        return [number boolValue];
+    }
+}
+
 #pragma mark - Gesture Recognition
 
 - (void)didRecognizeTapWithGestureRecognizer:(UITapGestureRecognizer *)recognizer
@@ -1308,13 +1402,35 @@ NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey = @"PKReveal
 - (CGRect)frontViewFrameForVisibleLeftView
 {
     CGFloat offset = [self leftViewMinWidth];
-    return CGRectOffset([self frontViewFrameForCenter], offset, 0.0f);
+    CGRect frame = [self frontViewFrameForCenter];
+
+    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    
+    if (self.resizesFrontViewControllerOnLandscape && UIInterfaceOrientationIsLandscape(orientation)) {
+        frame.size.width -= offset;
+    } else if (self.resizesFrontViewControllerOnPortrait && UIInterfaceOrientationIsPortrait(orientation)) {
+        frame.size.width -= offset;
+    }
+
+    return CGRectOffset(frame, offset, 0.0f);
 }
 
 - (CGRect)frontViewFrameForVisibleRightView
 {
     CGFloat offset = [self rightViewMinWidth];
-    return CGRectOffset([self frontViewFrameForCenter], -offset, 0.0f);
+    CGRect frame = [self frontViewFrameForCenter];
+
+    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+
+    if (self.resizesFrontViewControllerOnLandscape && UIInterfaceOrientationIsLandscape(orientation)) {
+        frame.size.width -= offset;
+        return frame;
+    } else if (self.resizesFrontViewControllerOnPortrait && UIInterfaceOrientationIsPortrait(orientation)) {
+        frame.size.width -= offset;
+        return frame;
+    }
+
+    return CGRectOffset(frame, -offset, 0.0f);
 }
 
 - (CGRect)frontViewFrameForCenter
@@ -1441,6 +1557,20 @@ NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey = @"PKReveal
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
                                          duration:(NSTimeInterval)duration
 {
+    if (UIInterfaceOrientationIsPortrait(toInterfaceOrientation)) {
+        if (self.opensLeftViewControllerOnPortrait) {
+            [self showViewController:self.leftViewController];
+        } else if (self.opensLeftViewControllerOnLandscape) {
+            [self showViewController:self.frontViewController];
+        }
+    } else {
+        if (self.opensLeftViewControllerOnLandscape) {
+            [self showViewController:self.leftViewController];
+        } else if (self.opensLeftViewControllerOnPortrait) {
+            [self showViewController:self.frontViewController];
+        }
+    }
+
     [self.frontViewContainer refreshShadowWithAnimationDuration:duration];
 }
 


### PR DESCRIPTION
... of the frontViewController.

Four new options, useful when using on iPad (keep the frontViewController the same size by always opening the leftViewController when changing orientation to landscape.
opensLeftViewControllerOnPortrait
opensLeftViewControllerOnLandscape
resizesFrontViewControllerOnPortrait
resizesFrontViewControllerOnLandscape

I'm using opensLeftViewControllerOnLandscape & resizesFrontViewControllerOnLandscape on iPad to keep frontViewController the same width. Those features should also cover the #127 issue.
