### PR TITLE
Updated ZUUIRevealVC to initialize from xib / storyboard

### DIFF
--- a/ZUUIRevealController/ZUUIRevealController.m
+++ b/ZUUIRevealController/ZUUIRevealController.m
@@ -101,6 +101,17 @@
 	return self;
 }
 
+// Raj: Added support loading ZUUIRevealVC from xib / storyboard
+-(id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self)
+    {
+        [self _loadDefaultConfiguration];
+    }
+    return self;
+}
+
 - (void)_loadDefaultConfiguration
 {
 	self.rearViewRevealWidth = 260.0f;


### PR DESCRIPTION
A simple addition of -initWithCoder method will ensure that we can even initialize the ZUUIRevealController from xib / storyboard.
