### PR TITLE
Fixes cut off viewController issue when calling - (void)setFrontViewCont...

### DIFF
--- a/PKRevealController/Controller/PKRevealControllerContainerView.m
+++ b/PKRevealController/Controller/PKRevealControllerContainerView.m
@@ -92,7 +92,7 @@
     {
         [_viewController.view removeFromSuperview];
         _viewController = controller;
-        _viewController.view.frame = _viewController.view.bounds;
+        _viewController.view.frame = self.bounds;
         [self addSubview:_viewController.view];
     }
 }


### PR DESCRIPTION
PKRevealController would not properly resize contents of PKRevealControllerContainerView when calling  - (void)setFrontViewController:(UIViewController *)frontViewController;. This issue only occurred in certain situations / iOS releases.
