### PR TITLE
Fix for behavioral bugs after changing a view controller.

### DIFF
--- a/Source/PKRevealController/PKRevealController.m
+++ b/Source/PKRevealController/PKRevealController.m
@@ -1074,6 +1074,9 @@ typedef struct
         childController.view.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
         childController.revealController = self;
         [container addSubview:childController.view];
+		if ([container isKindOfClass:[PKRevealControllerView class]]) {
+			((PKRevealControllerView *)container).viewController = childController;
+		}
         [self didMoveToParentViewController:self];
     }
 }


### PR DESCRIPTION
If the FrontViewController is changed to a new ViewController at runtime, several bugs can manifest due to the PKRevealControllerView no longer having a valid viewController reference to prevent unwanted touches on.
This fix updates the .viewController property on the container view when a new ViewController is set.
