### PR TITLE
Simplified UIViewController category

### DIFF
--- a/Source/PKRevealController/Categories/UIViewController+PKRevealController.m
+++ b/Source/PKRevealController/Categories/UIViewController+PKRevealController.m
@@ -44,12 +44,7 @@ static char revealControllerKey;
     
     if (!controller)
     {
-        if (self.parentViewController)
-        {
-            return [self.parentViewController revealController];
-        }
-        
-        return nil;
+        controller = self.parentViewController.revealController;
     }
     
     return controller;


### PR DESCRIPTION
Objective-C runtime can handle the message to nil. Now it has only one return.
