### PR TITLE
Bug Fixes

### DIFF
--- a/Source/PKRevealController/PKRevealController.m
+++ b/Source/PKRevealController/PKRevealController.m
@@ -1077,7 +1077,7 @@ typedef struct
 		if ([container isKindOfClass:[PKRevealControllerView class]]) {
 			((PKRevealControllerView *)container).viewController = childController;
 		}
-        [self didMoveToParentViewController:self];
+        [childController didMoveToParentViewController:self];
     }
 }
 


### PR DESCRIPTION
When adding a child controller to a container, it should call child's
didMoveToParentViewController, not "self"
