### PR TITLE
Initialize state to a well defined value.

### DIFF
--- a/Source/PKRevealController/PKRevealController.m
+++ b/Source/PKRevealController/PKRevealController.m
@@ -552,6 +552,7 @@ typedef struct
     _leftViewWidthRange = DEFAULT_LEFT_VIEW_WIDTH_RANGE;
     _rightViewWidthRange = DEFAULT_RIGHT_VIEW_WIDTH_RANGE;
     _recognizesResetTapOnFrontViewInPresentationMode = DEFAULT_RECOGNIZES_RESET_TAP_ON_FRONT_VIEW_IN_PRESENTATION_MODE_VALUE;
+    _state = PKRevealControllerShowsFrontViewController;
 }
 
 - (void)setupContainerViews


### PR DESCRIPTION
In iOS v7.1, the preferredStatusBar style is incorrectly detected. This
fixes the problem by setting the state to match the initial state of
the controller.
