### PR TITLE
Take the value of `disablesFrontViewInteraction` into account

### DIFF
--- a/Source/PKRevealController/PKRevealController.m
+++ b/Source/PKRevealController/PKRevealController.m
@@ -1002,7 +1002,7 @@ typedef struct
     self.leftView.hidden = YES;
     [self removeViewController:self.leftViewController];
     [self addViewController:self.rightViewController container:self.rightView];
-    [self.frontView setUserInteractionForContainedViewEnabled:NO];
+    [self.frontView setUserInteractionForContainedViewEnabled:!_disablesFrontViewInteraction];
 }
 
 - (void)showLeftView
@@ -1011,7 +1011,7 @@ typedef struct
     self.leftView.hidden = NO;
     [self removeViewController:self.rightViewController];
     [self addViewController:self.leftViewController container:self.leftView];
-    [self.frontView setUserInteractionForContainedViewEnabled:NO];
+    [self.frontView setUserInteractionForContainedViewEnabled:!_disablesFrontViewInteraction];
 }
 
 - (BOOL)isLeftViewVisible


### PR DESCRIPTION
When showing the left or right view, we should enable or disable user interactions depending on the value of the `disablesFrontViewInteraction` property. We used to always disable those interactions, which is certainly the cause of #172.
