### PR TITLE
updateRearViewVisibilityForFrontViewPosition: should update self.state t...

### DIFF
--- a/Source/PKRevealController/PKRevealController.m
+++ b/Source/PKRevealController/PKRevealController.m
@@ -909,6 +909,8 @@ typedef struct
     {
         [self hideRearViews];
     }
+    
+    self.state = [self stateForCurrentFrontViewPosition];
 }
 
 - (void)updateRearViewVisibility


### PR DESCRIPTION
updateRearViewVisibilityForFrontViewPosition: should update self.state the same way updateRearViewVisibility does.  Otherwise, the timing is off for the willChangeToState/didChangeToState calls to the delegate.
