### PR TITLE
Fixed compiler warning for minor documentation issue

### DIFF
--- a/Source/PKRevealController/PKRevealController.h
+++ b/Source/PKRevealController/PKRevealController.h
@@ -229,7 +229,7 @@ FOUNDATION_EXTERN NSString * const PKRevealControllerRecognizesResetTapOnFrontVi
  Adjusts the minimum and maximum reveal width of any given view controller's view.
  
  @param minWidth The default (minimum) width of the view to be shown.
- @param minWidth The maximum width of the view to be shown when overdrawing (if applicable) or entering presentation mode.
+ @param maxWidth The maximum width of the view to be shown when overdrawing (if applicable) or entering presentation mode.
  @param controller The view controller whose view reveal sizing is being adjusted.
  */
 - (void)setMinimumWidth:(CGFloat)minWidth


### PR DESCRIPTION
Fixed a minor documentation issue for the method 

`- (void)setMinimumWidth:(CGFloat)minWidth
           maximumWidth:(CGFloat)maxWidth
      forViewController:(UIViewController *)controller;`

which removes a compiler warning when using the pod.

`@param minWidth` was declared twice.
