### PR TITLE
Possible fix for Wmissing-variable-declarations

### DIFF
--- a/Source/PKRevealController/PKRevealController.m
+++ b/Source/PKRevealController/PKRevealController.m
@@ -50,7 +50,7 @@ NSString * const PKRevealControllerQuickSwipeToggleVelocityKey = @"quickSwipeVel
 NSString * const PKRevealControllerDisablesFrontViewInteractionKey = @"disablesFrontViewInteraction";
 NSString * const PKRevealControllerRecognizesPanningOnFrontViewKey = @"recognizesPanningOnFrontView";
 NSString * const PKRevealControllerRecognizesResetTapOnFrontViewKey = @"recognizesResetTapOnFrontView";
-NSString * const PKRevealControllerRecognizesResetTapOnFrontViewInPresentationModeKey = @"recognizesResetTapOnFrontViewInPresentationMode";
+static NSString * const PKRevealControllerRecognizesResetTapOnFrontViewInPresentationModeKey = @"recognizesResetTapOnFrontViewInPresentationMode";
 
 static NSString *kPKRevealControllerFrontViewTranslationAnimationKey = @"frontViewTranslation";
 


### PR DESCRIPTION
This variable is only ever used in this implementation file. Annotating it with static makes that more clear.

Or, maybe it should be deleted? Or add an extern declaration in the header file?
