### PR TITLE
Fixed 2 [-Wabsolute-value] warnings

### DIFF
--- a/Source/PKRevealController/PKRevealController.m
+++ b/Source/PKRevealController/PKRevealController.m
@@ -825,7 +825,7 @@ typedef struct
 {
     BOOL isNegative = (realValue < 0);
     
-    realValue = fabsf(realValue);
+    realValue = fabs(realValue);
     
     // PKLog(@"Range: [%u, %u], Real Value: %f", absoluteRange.location, (absoluteRange.location + absoluteRange.length), realValue);
     
@@ -1061,7 +1061,7 @@ typedef struct
 
 - (BOOL)shouldMoveFrontViewLeftwardsForVelocity:(CGFloat)velocity
 {
-    return (velocity < 0 && fabsf(velocity) > self.quickSwipeVelocity);
+    return (velocity < 0 && fabs(velocity) > self.quickSwipeVelocity);
 }
 
 #pragma mark - View Controller Containment


### PR DESCRIPTION
Warnings are caused by the argument type being a CGFloat (of type double) but has a parameter of type float which may cause truncation of a value.