### PR TITLE
if self.layer.shadowPath is nil bezierPathWithCGPath will raise NSInvalidArgumentException

### DIFF
--- a/Source/PKRevealController/Classes/PKRevealControllerView.m
+++ b/Source/PKRevealController/Classes/PKRevealControllerView.m
@@ -74,7 +74,7 @@ static NSString *kShadowTransitionAnimationKey = @"shadowTransitionAnimation";
 {
     UIBezierPath *existingShadowPath = nil;
     
-    if (self.layer.shadowPath)
+    if (self.layer.shadowPath != nil)
     {
         existingShadowPath = [UIBezierPath bezierPathWithCGPath:self.layer.shadowPath];
     }

--- a/Source/PKRevealController/Classes/PKRevealControllerView.m
+++ b/Source/PKRevealController/Classes/PKRevealControllerView.m
@@ -72,7 +72,12 @@ static NSString *kShadowTransitionAnimationKey = @"shadowTransitionAnimation";
 
 - (void)updateShadowWithAnimationDuration:(NSTimeInterval)duration
 {
-    UIBezierPath *existingShadowPath = [UIBezierPath bezierPathWithCGPath:self.layer.shadowPath];
+    UIBezierPath *existingShadowPath = nil;
+    
+    if (self.layer.shadowPath)
+    {
+        existingShadowPath = [UIBezierPath bezierPathWithCGPath:self.layer.shadowPath];
+    }
     
     self.layer.shadowPath = [UIBezierPath bezierPathWithRect:self.bounds].CGPath;
     


### PR DESCRIPTION
Still investigating how my app caused this to happen. Checking for self.layer.shadowPath's existence prevented the crash.
