### PR TITLE
Only add/remove view controllers if the view is loaded.

### DIFF
--- a/Source/PKRevealController/PKRevealController.m
+++ b/Source/PKRevealController/PKRevealController.m
@@ -408,14 +408,14 @@ typedef struct
 {
     if (frontViewController != _frontViewController)
     {
-        if (_frontViewController)
+        if (_frontViewController && ![self isViewLoaded])
         {
             [self removeViewController:_frontViewController];
         }
         
         _frontViewController = frontViewController;
         
-        if (_frontViewController)
+        if (_frontViewController && ![self isViewLoaded])
         {
             [self addViewController:_frontViewController container:self.frontView];
         }
@@ -426,14 +426,14 @@ typedef struct
 {
     if (leftViewController != _leftViewController)
     {
-        if (_leftViewController)
+        if (_leftViewController && ![self isViewLoaded])
         {
             [self removeViewController:_leftViewController];
         }
         
         _leftViewController = leftViewController;
         
-        if (_leftViewController)
+        if (_leftViewController && ![self isViewLoaded])
         {
             [self addViewController:_leftViewController container:self.leftView];
         }
@@ -444,14 +444,14 @@ typedef struct
 {
     if (rightViewController != _rightViewController)
     {
-        if (_rightViewController)
+        if (_rightViewController && ![self isViewLoaded])
         {
             [self removeViewController:_rightViewController];
         }
         
         _rightViewController = rightViewController;
         
-        if (_rightViewController)
+        if (_rightViewController && ![self isViewLoaded])
         {
             [self addViewController:_rightViewController container:self.rightView];
         }


### PR DESCRIPTION
This fix allows setting the view controller prior to the view controller loading. This allows setting view controllers in a subclass initializer.