### PR TITLE
Left and right view are no longer clipped by the front view

### DIFF
--- a/Source/PKRevealController/PKRevealController.m
+++ b/Source/PKRevealController/PKRevealController.m
@@ -474,6 +474,7 @@ typedef struct
     {
         self.rightViewWidthRange = range;
     }
+    [self setContainerViewsSizes];
 }
 
 - (void)setOptions:(NSDictionary *)options
@@ -560,10 +561,11 @@ typedef struct
 
 - (void)setupContainerViews
 {
-    self.rightView = [[PKRevealControllerView alloc] initWithFrame:self.view.bounds];
-    self.leftView = [[PKRevealControllerView alloc] initWithFrame:self.view.bounds];
-    self.frontView = [[PKRevealControllerView alloc] initWithFrame:self.view.bounds];
-    
+    self.rightView = [PKRevealControllerView new];
+    self.leftView = [PKRevealControllerView new];
+    self.frontView = [PKRevealControllerView new];
+    [self setContainerViewsSizes];
+
     self.rightView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     self.leftView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     self.frontView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
@@ -584,6 +586,14 @@ typedef struct
     [self addViewController:self.frontViewController container:self.frontView];
     [self addViewController:self.leftViewController container:self.leftView];
     [self addViewController:self.rightViewController container:self.rightView];
+}
+
+- (void)setContainerViewsSizes
+{
+    CGRect superBounds = self.view.bounds;
+    self.leftView.frame = CGRectMake(superBounds.origin.x, superBounds.origin.y, [self leftViewMaxWidth], CGRectGetHeight(superBounds));
+    self.rightView.frame = CGRectMake(superBounds.origin.x, superBounds.origin.y, [self rightViewMaxWidth], CGRectGetHeight(superBounds));
+    self.frontView.frame = superBounds;
 }
 
 - (void)setupGestureRecognizers


### PR DESCRIPTION
This pull request sets the width of the left and right views to the value returned by `[self leftViewMaxWidth]` and `[self rightViewMaxWidth]`, instead of the whole parent width (the PKRevealController view). This avoids the clipping occurred in those views when they are revealed.

You can change the width of any of the view using the method ´setMinimumWidth:maximumWidth:forViewController:`. Take into account that if the min and max have different values, some clipping may still occur. The hidden part (between min and max values) will be shown when the user "tries" to reveal the view beyond the min value.
